### PR TITLE
Make bodyParser.json limit configurable in config file

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,7 @@ server.start = function (configManager) {
   // Allow extensions to  override route callbacks.
   configManager.invokeExtensions('alterRoutes', routes);
 
-  app.use(bodyParser.json({}));
+  app.use(bodyParser.json({limit: settings.bodyParserJsonLimit}));
 
   app.use(function (request, response, next) {
     // Make objects available to route callbacks.
@@ -65,7 +65,7 @@ server.start = function (configManager) {
       app.get(route.path, route.handler);
     }
   });
-  
+
   app.get('*', routes.send404);
 
   var httpServer;

--- a/nodejs.config.js.example
+++ b/nodejs.config.js.example
@@ -87,6 +87,7 @@ settings = {
     messagePath: '/nodejs/message'
   },
   debug: false,
+  bodyParserJsonLimit: '16mb',
   sslKeyPath: '',
   sslCertPath: '',
   sslCAPath: '',


### PR DESCRIPTION
I was using drupal/nodejs with kint and it was complaining with:

PayloadTooLargeError: request entity too large

This worked for me.