### PR TITLE
Refactor Socket.io server configuration

### DIFF
--- a/lib/config-manager.js
+++ b/lib/config-manager.js
@@ -11,16 +11,11 @@ var configManager = {
   extensions: [],
   settingsDefaults: {
     scheme: 'http',
-    port: 8080,
     host: 'localhost',
-    resource: '/socket.io',
     serviceKey: '',
     debug: false,
     baseAuthPath: '/nodejs/',
     extensions: [],
-    transports: ['websocket', 'polling'],
-    jsMinification: true,
-    jsEtag: true,
     backend: {
       host: 'localhost',
       scheme: 'http',
@@ -30,7 +25,8 @@ var configManager = {
       messagePath: 'nodejs/message',
       httpAuth: ''
     },
-    logLevel: 1
+    port: 8080,
+    socketOptions: {}
   }
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -89,22 +89,7 @@ server.start = function (configManager) {
   httpServer.listen(settings.port, settings.host);
   console.log('Started ' + settings.scheme + ' server.');
 
-  var io_options = {};
-  io_options['transports'] = settings.transports;
-  io_options['log level'] = settings.logLevel;
-  io_options['port'] = settings.port;
-
-  if (settings.jsEtag) {
-    io_options['browser client etag'] = true;
-  }
-  if (settings.jsMinification) {
-    io_options['browser client minification'] = true;
-  }
-
-  var io = require('socket.io')(httpServer, io_options);
-
-  io.set('resource', settings.resource);
-  io.set('transports', settings.transports);
+  var io = require('socket.io')(httpServer, settings.socketOptions);
 
   io.on('connection', function(socket) {
       clientManager.addSocket(socket);

--- a/nodejs.config.js.example
+++ b/nodejs.config.js.example
@@ -7,16 +7,10 @@
  * contact the Drupal site using http or https. If https is used, the key and
  * cert must be set to valid files. Defaults to 'http'.
  *
- * port: Specify the TCP port that the node server should listen on. Defaults
- * to '8080'.
- *
  * host: Specify the host name or IP address that the node server should listen
  * on. Leave blank to listen for any host name. Otherwise, the server will only
  * respond to names that match the IP address given (or resolved from the given
  * name). Defaults to 'localhost'.
- *
- * resource: http path that the node server should respond to. This value needs
- * to match the Drupal node.js configuration. Defaults to '/socket.io'.
  *
  * serviceKey: An arbitrary string used as a secret between the node.js server
  * and the Drupal site.
@@ -59,21 +53,17 @@
  * extensions: An array of names of node.js modules that should be loaded as
  * extensions to the node.js server.
  *
- * transports: a list of transports to be used by Socket.Io, defaults to
- * ['websocket', 'polling'].
+ * port: Specify the TCP port that the node server should listen on. Defaults
+ * to '8080'.
  *
- * jsMinification: whether to call io.enable('browser client minification'),
- * defaults to 'true'.
- *
- * jsEtag: whether to call io.enable('browser client etag').
- *
- * logLevel: the log level to be used by Socket.Io, defaults to '1'.
+ * socketOptions: An object with properties to configure the Socket.io
+ * instance. See the Socket.io documentation for a list of valid values:
+ *   https://socket.io/docs/server-api/#new-Server-httpServer-options
  */
 settings = {
   scheme: 'http',
   port: 8080,
   host: 'localhost',
-  resource: '/socket.io',
   serviceKey: '',
   backend: {
     port: 80,
@@ -88,8 +78,5 @@ settings = {
   sslCAPath: '',
   baseAuthPath: '/nodejs/',
   extensions: [],
-  transports: ['websocket', 'polling'],
-  jsMinification: true,
-  jsEtag: true,
-  logLevel: 1
+  socketOptions: {}
 };

--- a/test/test.js
+++ b/test/test.js
@@ -21,8 +21,6 @@ describe('Server app', function () {
     debug: false,
     baseAuthPath: '/nodejs/',
     extensions: [],
-    clientsCanWriteToChannels: false,
-    clientsCanWriteToClients: false,
     transports: ['websocket', 'polling'],
     jsMinification: true,
     jsEtag: true,
@@ -40,7 +38,10 @@ describe('Server app', function () {
       uid: 666,
       clientId: 'lotestclientid'
     },
-    logLevel: 1
+    logLevel: 1,
+    socketOptions: {
+      path: '/some-other-path'
+    }
   };
 
   var serverUrl = url.format({
@@ -159,7 +160,7 @@ describe('Server app', function () {
   });
 
   it('should allow client connections with valid tokens', function(done) {
-    client = io.connect(settings.scheme + '://' + settings.host + ':' + settings.port);
+    client = io.connect(settings.scheme + '://' + settings.host + ':' + settings.port, {path: settings.socketOptions.path});
     client.on('connect', function() {
       authResult.clientId = client.nsp + '#' + client.id;
       nock(backendHost).post(backendMessagePath, bodyMatch).reply(200, authResult);
@@ -171,7 +172,7 @@ describe('Server app', function () {
   });
 
   it('should disconnect client connections with invalid tokens', function(done) {
-    client = io.connect(settings.scheme + '://' + settings.host + ':' + settings.port);
+    client = io.connect(settings.scheme + '://' + settings.host + ':' + settings.port, {path: settings.socketOptions.path});
     client.on('connect', function() {
       authResult.clientId = client.nsp + '#' + client.id;
       authResult.nodejsValidAuthToken = false;


### PR DESCRIPTION
This is well past due. The defaults were wrong, and it was impossible
to set all the available options from Socket.io upstream.

Thanks @stephenthedev for the initial PR!